### PR TITLE
Event creation form enhancements

### DIFF
--- a/src/backend/bsd.js
+++ b/src/backend/bsd.js
@@ -473,7 +473,7 @@ export default class BSD {
     })
 
     if (eventType === null){
-      callback('Event type does not exist in BSD');
+      callback('failure', {'Event Type':['does not exist in BSD']});
       return;
     }
 
@@ -528,12 +528,12 @@ export default class BSD {
       let startTime = newEvent['date'] + ' ' + startHour + ':' + form['start_time']['i'] + ':00'
       params['days'][0]['start_datetime_system'] = startTime;
       let response = await this.request('/event/create_event', {event_api_version: 2, values: JSON.stringify(params)}, 'POST');
-      if (response.validation_errors){
-        callback(response.validation_errors);
+	  if (response.validation_errors){
+        callback('failure', response.validation_errors);
       }
       else if (response.event_id_obfuscated && index == array.length - 1){
         // successfully created events
-        callback('success');
+        callback('success', {'event_id_obfuscated' : response.event_id_obfuscated});
       }
     });
 

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -265,7 +265,10 @@ app.post('/logout',
 )
 
 app.get('/admin/events/create', isAuthenticated, wrap(async (req, res) => {
-  res.send(createEventPage({is_public: false}));
+  //res.send(createEventPage({is_public: false}));
+  const t = fs.readFileSync(templateDir + '/create_event.hbs', {encoding: 'utf-8'});
+  const p = handlebars.compile(t);
+  res.send(p({is_public: false}));
 }))
 
 app.get('/events/create', wrap(async (req, res) => {
@@ -298,7 +301,7 @@ app.post('/events/create', wrap(async (req, res) => {
 
   
   // send event creation confirmation email
-  function eventCreationCallback(status, event_id_obfuscated) {
+  function eventCreationCallback(status, details) {
     let response_data = {'status' : status};
     if (status == 'success') {
       if (form['event_type_id'] == 31) {
@@ -310,9 +313,10 @@ app.post('/events/create', wrap(async (req, res) => {
         // Send generic email
         Mailgun.sendEventConfirmation(form, constituent, event_types)
       }
-      response_data['event_url'] = 'https://go.berniesanders.com/page/event/detail/' + event_id_obfuscated;
+      response_data['event_url'] = 'https://go.berniesanders.com/page/event/detail/' + details.event_id_obfuscated;
   	} else {
-      clientLogger['error']('Event Creation Error:', status)
+      response_data['validation_errors'] = details;
+      clientLogger['error']('Event Creation Error:', details);
     }
 	res.json(response_data);
   }

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -296,11 +296,11 @@ app.post('/events/create', wrap(async (req, res) => {
   let event_types = await BSDClient.getEventTypes()
   await BSDClient.createEvents(constituent.id, form, event_types, eventCreationCallback)
 
+  
   // send event creation confirmation email
-  function eventCreationCallback(status) {
-  	res.json(status)
-
-  	if (status == 'success') {
+  function eventCreationCallback(status, event_id_obfuscated) {
+    let response_data = {'status' : status};
+    if (status == 'success') {
       if (form['event_type_id'] == 31) {
         // Send phone bank specific email
         // Mailgun.sendPhoneBankConfirmation(form, constituent)
@@ -310,9 +310,11 @@ app.post('/events/create', wrap(async (req, res) => {
         // Send generic email
         Mailgun.sendEventConfirmation(form, constituent, event_types)
       }
+      response_data['event_url'] = 'https://go.berniesanders.com/page/event/detail/' + event_id_obfuscated;
   	} else {
       clientLogger['error']('Event Creation Error:', status)
     }
+	res.json(response_data);
   }
 }))
 

--- a/src/frontend/public/admin/events/create_event.hbs
+++ b/src/frontend/public/admin/events/create_event.hbs
@@ -74,18 +74,32 @@
 		    }
 		}
 
-		.event-central.step2 #SKIN .section-wrap#event-message {
+		.event-central.step2 #SKIN .section-wrap.event-message {
 		    max-width: 600px;
 		    margin: 2rem auto;
 			color:white;
 			padding:0.8rem 2.2rem;
 		}
 
-		div#event-message a:link,
-		div#event-message a:visited,
-		div#event-message a:hover,
-		div#event-message a:active {
+		div.event-message a:link,
+		div.event-message a:visited,
+		div.event-message a:hover,
+		div.event-message a:active {
 			color: #DBE1E6;
+		    text-decoration: underline;
+		}
+
+		.event-central.step2 #SKIN .section-wrap#event-error-message {
+		    color: #a94442;
+		    background-color: #f2dede;
+		    border-color: #ebccd1;
+		}
+
+		div#event-error-message a:link,
+		div#event-error-message a:visited,
+		div#event-error-message a:hover,
+		div#event-error-message a:active {
+			color: #a94442;
 		    text-decoration: underline;
 		}
 
@@ -115,9 +129,16 @@
     <div class="content" style="visibility: visible;">
       <div id="SKIN" class="module_event2 bsd-page bsd-event bsd-event-createdetails">
         <div class="basic container">
-		  <div id="event-message" class="section-wrap" style="display:none;">
+		  <div id="event-success-message" class="section-wrap event-message" style="display:none;">
 			  Thanks for submitting an <a class="js-created-event-url" href="" target="_blank">event</a> for the Bernie Sanders campaign!<br> 
 			  You should receive a confirmation email with a link to manage your event in a few minutes.
+		  </div>
+		  
+		  <div id="event-error-message" class="section-wrap event-message" style="display:none;">
+			  There was an error processing your submission. <br>
+			  Please try again later or contact 
+			  <a href="mailto:help@berniesanders.com?Subject=Error%20encountered%20creating%20event" target="_top">help@berniesanders.com</a>
+			  <ul id="event-error-message-details"></ul>
 		  </div>
 			
           <form method="post" name="secondform" id="secondform">
@@ -1456,7 +1477,8 @@
 
           	$('#secondform').submit(function(e){
           		e.preventDefault();
-
+				$("#event-success-message, #event-error-message").hide();
+				
           		current_events = $.merge( $.merge( [], user_created_events ), generated_events );
           		if (current_events.length < 1){
           			alert('Please select a date for your event from the calendar.');
@@ -1471,8 +1493,8 @@
           			value: JSON.stringify(current_events)
           		});
 				
-				setHashValue("event_url", null);
-				
+							setHashValue("event_url", null);
+  						window.scrollTo(0,0);
           		$.ajax({
           		    dataType: "json",
           		    url: '/events/create',
@@ -1480,30 +1502,32 @@
           		    type: 'POST',
           		    success: function(response, textStatus){
           		    	if (response.status == 'success'){
-							setHashValue("event_url", response.event_url);
-				  		  // Scroll to top where a message will get displayed 
-				  			window.scrollTo(0,0);
-							window.location.reload();
-          		    	}
-          		    	else {
-          		    		alert('There was an error processing your submission. Please try again later or contact help@berniesanders.com.');
-          		    		$('#submit_button').removeClass('in-progress');
+											setHashValue("event_url", response.event_url);
+				  		    		// Scroll to top where a message will get displayed 
+											window.location.reload();
+          		    	} else {
+											$('#submit_button').removeClass('in-progress');
+											$("#event-error-message-details").html();
+											$.each(response.validation_errors, function(k, v) {
+											  $("#event-error-message-details").append("<li>" + k + " : " + v[0] + "</li>");
+											});
+											$("#event-error-message").show();
           		    	}
           		    },
           		    error: function(i){
-					  console.log(i);
-					  alert('There was an error processing your submission. Please try again later or contact help@berniesanders.com.');
+					  				console.log(i);
           		      $('#submit_button').removeClass('in-progress');
+										$("#event-error-message").show();
           		    }
           		});
           	});
-			
+
 			
 			// Show initial modal if we have an event_url in the hash (should have come from previous event creation)
 			var created_event_url = getHashValue("event_url");
 			if (created_event_url) {
 				$(".js-created-event-url").attr("href", created_event_url);
-				$("#event-message").show();
+				$("#event-success-message").show();
 			}
 			
           });

--- a/src/frontend/public/admin/events/create_event.hbs
+++ b/src/frontend/public/admin/events/create_event.hbs
@@ -73,6 +73,22 @@
 		        float: none !important;
 		    }
 		}
+
+		.event-central.step2 #SKIN .section-wrap#event-message {
+		    max-width: 600px;
+		    margin: 2rem auto;
+			color:white;
+			padding:0.8rem 2.2rem;
+		}
+
+		div#event-message a:link,
+		div#event-message a:visited,
+		div#event-message a:hover,
+		div#event-message a:active {
+			color: #DBE1E6;
+		    text-decoration: underline;
+		}
+
     </style>
     <script src="/admin/events/static/ckeditor/ckeditor.js"></script>
     <script src="/admin/events/static/less.js"></script>
@@ -99,6 +115,11 @@
     <div class="content" style="visibility: visible;">
       <div id="SKIN" class="module_event2 bsd-page bsd-event bsd-event-createdetails">
         <div class="basic container">
+		  <div id="event-message" class="section-wrap" style="display:none;">
+			  Thanks for submitting an <a class="js-created-event-url" href="" target="_blank">event</a> for the Bernie Sanders campaign!<br> 
+			  You should receive a confirmation email with a link to manage your event in a few minutes.
+		  </div>
+			
           <form method="post" name="secondform" id="secondform">
             <div>
               <div class="section-wrap">
@@ -1274,7 +1295,7 @@
           </form>
         </div>
         <script type="text/javascript">
-          var isPublic = {{#if is_public }}true{{else}}false{{/if}};
+		  var isPublic = {{#if is_public }}true{{else}}false{{/if}};
           var $, events_cal;
           var events = [];
           var user_created_events = [];
@@ -1449,17 +1470,20 @@
           			name: "event_dates",
           			value: JSON.stringify(current_events)
           		});
-
+				
+				setHashValue("event_url", null);
+				
           		$.ajax({
           		    dataType: "json",
           		    url: '/events/create',
           		    data: formdata,
           		    type: 'POST',
-          		    success: function(xhr, status){
-          		    	if (xhr == 'success'){
-          		    		// temporary success message, to be replaced with a nice UI update in the future
-          		    		alert('Thanks for submitting an event for the Bernie Sanders campaign! You should receive a confirmation email with a link to manage your event in a few minutes.');
-          		    		window.location.reload();
+          		    success: function(response, textStatus){
+          		    	if (response.status == 'success'){
+							setHashValue("event_url", response.event_url);
+				  		  // Scroll to top where a message will get displayed 
+				  			window.scrollTo(0,0);
+							window.location.reload();
           		    	}
           		    	else {
           		    		alert('There was an error processing your submission. Please try again later or contact help@berniesanders.com.');
@@ -1467,13 +1491,21 @@
           		    	}
           		    },
           		    error: function(i){
-          		      console.log(i);
-          		      alert('There was an error processing your submission. Please try again later or contact help@berniesanders.com.');
+					  console.log(i);
+					  alert('There was an error processing your submission. Please try again later or contact help@berniesanders.com.');
           		      $('#submit_button').removeClass('in-progress');
           		    }
           		});
           	});
-
+			
+			
+			// Show initial modal if we have an event_url in the hash (should have come from previous event creation)
+			var created_event_url = getHashValue("event_url");
+			if (created_event_url) {
+				$(".js-created-event-url").attr("href", created_event_url);
+				$("#event-message").show();
+			}
+			
           });
         </script>
         <script>

--- a/src/frontend/public/admin/events/static/event-types.js
+++ b/src/frontend/public/admin/events/static/event-types.js
@@ -65,7 +65,7 @@ function setDefaults(eventTypeId){
 	}
 	if (!eventType) {return};	
 
-	window.location.hash = "type=" + eventType.id;
+	setHashValue("type", eventType.id);
 	var defaults = eventType.defaultValues;	
 
 	clearEvents();
@@ -162,4 +162,24 @@ function updateEventTime(dateMoment) {
 function getHashValue(key) {
   var matches = location.hash.match(new RegExp(key+'=([^&]*)'));
   return matches ? matches[1] : null;
+}
+
+function setHashValue(key, value) {
+  var hash = window.location.hash;
+  var re = new RegExp(key + "=.*?(&|#|$)(.*)", "i");
+  var updated_hash = "";
+  if (hash.match(re)) {
+	if (typeof value !== 'undefined' && value !== null) {
+      updated_hash =  hash.replace(re, key + "=" + value + '$1$2');
+    } else {
+	  updated_hash =  hash.replace(re,'');
+    }
+  }
+  else if (typeof value !== 'undefined' && value !== null) {
+	if (hash != "" ) {
+		updated_hash = hash + "&";
+	}
+    updated_hash += key + "=" + value;
+  }
+  window.location.hash = updated_hash;
 }


### PR DESCRIPTION
This PR tackles #440 and #435 by providing a better feedback to the user when event creation:
* succeed (link to event details page)
<img width="658" alt="screen shot 2016-01-11 at 4 37 38 pm" src="https://cloud.githubusercontent.com/assets/124953/12250104/c4c29cc4-b881-11e5-8f2a-55974049a129.png">


* failed : provide error message
<img width="672" alt="screen shot 2016-01-11 at 4 38 16 pm" src="https://cloud.githubusercontent.com/assets/124953/12250101/c2a6d496-b881-11e5-80f0-8fe6e84ce73e.png">

