### PR TITLE
Lower Default Target Universe to 250 nearby people in FastFwd tool (closes #530)

### DIFF
--- a/src/frontend/components/AdminEventEmailCreationForm.js
+++ b/src/frontend/components/AdminEventEmailCreationForm.js
@@ -70,11 +70,19 @@ class AdminEventEmailCreationForm extends React.Component {
     return shuffled.slice(0, size)
   }
 
-  renderRecipientInfo() {
-    let recipientsCount = this.state.recipientLimit || (this.props.event.nearbyPeople.length + 1)
-    let recipientsSample = this.getRandomSubarray(this.props.event.nearbyPeople, 10)
+  renderRecipientInfo(recipientsCount) {
+    let recipientsSample = this.getRandomSubarray(this.props.event.nearbyPeople,
+						  Math.min(10, recipientsCount))
 
-    if (recipientsCount === 0) {
+    if (this.state.testMode) {
+      return (
+        <Paper zDepth={1} style={this.styles.recipientInfoContainer}>
+          <p style={{color: 'red', fontWeight: 'strong'}}>
+            In test mode, this email will only be sent to you.
+          </p>
+        </Paper>
+        )
+    } else if (recipientsCount === 0) {
       return (
         <Paper zDepth={1} style={this.styles.recipientInfoContainer}>
           <p style={{color: 'red', fontWeight: 'strong'}}>
@@ -110,7 +118,7 @@ class AdminEventEmailCreationForm extends React.Component {
       recipients.push(this.props.event.host.id)
     }
 
-    let recipientLimit = this.state.recipientLimit || recipients.length
+    let recipientLimit = this.state.recipientLimit || Math.min(250, recipients.length)
 
     let disableSubmit = (this.props.event.nearbyPeople.length === 0)
 
@@ -170,10 +178,10 @@ class AdminEventEmailCreationForm extends React.Component {
             <br />
             <h4 style={BernieText.default}>Number of recipients: {recipientLimit} (plus you)</h4>
             <Slider
-              defaultValue={recipients.length}
+              defaultValue={recipientLimit}
               disabled={this.state.testMode}
               max={recipients.length}
-              min={1}
+              min={this.state.testMode ? 0 : 1}
               step={1}
               onChange={(_, newSliderValue) => {
                 this.setState({recipientLimit: newSliderValue})
@@ -194,7 +202,7 @@ class AdminEventEmailCreationForm extends React.Component {
           </GCForm>
         </Paper>
 
-        {this.renderRecipientInfo()}
+        {this.renderRecipientInfo(recipientLimit)}
 
         <Paper zDepth={1} style={this.styles.detailsContainer}>
           <EventPreview event={this.props.event} />


### PR DESCRIPTION
 * Leave the backend search at 500 limit, but default to 250 in the front end slider (user can still increase it back up to 500)

* Fix display bug in 'This email will be sent to:' RecipientInfoContainer
 * When slider is set to fewer than 10 recipients, don't show 10 sample recipients

* Provide more visual cues when entering test mode
 * Drop 'Number of recipients' and RecipientInfoContainer to zero