### PR TITLE
Pre-populate randomly chosen subject line in FastFwd tool (#517)

### DIFF
--- a/src/backend/data/schema.js
+++ b/src/backend/data/schema.js
@@ -1297,6 +1297,7 @@ const GraphQLCreateAdminEventEmail = mutationWithClientMutationId({
     hostEmail: { type: new GraphQLNonNull(GraphQLString) },
     senderEmail: { type: new GraphQLNonNull(GraphQLString) },
     adminEmail: { type: new GraphQLNonNull(GraphQLString) },
+    subject: { type: new GraphQLNonNull(GraphQLString) },
     hostMessage: { type: new GraphQLNonNull(GraphQLString) },
     senderMessage: { type: new GraphQLNonNull(GraphQLString) },
     recipients: { type: new GraphQLList(GraphQLString) },
@@ -1308,7 +1309,7 @@ const GraphQLCreateAdminEventEmail = mutationWithClientMutationId({
       resolve: () => SharedListContainer
     }
   },
-  mutateAndGetPayload: async ({hostEmail, senderEmail, adminEmail, hostMessage, senderMessage, recipients, toolPassword}, {rootValue}) => {
+  mutateAndGetPayload: async ({hostEmail, senderEmail, adminEmail, subject, hostMessage, senderMessage, recipients, toolPassword}, {rootValue}) => {
     adminRequired(rootValue)
 
     // TODO: remove this goofy protection when the tool is ready
@@ -1325,7 +1326,8 @@ const GraphQLCreateAdminEventEmail = mutationWithClientMutationId({
       senderAddress: senderEmail,
       hostMessage: hostMessage,
       senderMessage: senderMessage,
-      recipientAddress: adminEmail
+      recipientAddress: adminEmail,
+      subject: subject
     })
 
     knex.transaction(async (trx) => {

--- a/src/backend/email-templates/admin-event-invitation/text.hbs
+++ b/src/backend/email-templates/admin-event-invitation/text.hbs
@@ -2,7 +2,7 @@
 
 ---------- Forwarded message ----------
 From: {{hostAddress}}
-Subject: HELP! I need more people to come to my phonebank
+Subject: {{subject}}
 To: {{recipientAddress}}
 
 {{hostMessage}}

--- a/src/backend/mail.js
+++ b/src/backend/mail.js
@@ -172,13 +172,16 @@ export default class MG {
 
   async sendAdminEventInvite(data) {
     let template = new EmailTemplate(templateDir + '/admin-event-invitation')
+    if (data.subject.match(/^Fwd: /)) {
+      data.subject = data.subject.replace(/^Fwd: /, '')
+    }
     let content = await template.render(data)
 
     let message = {
       from: data.senderAddress,
       'h:Reply-To': data.hostAddress,
       to: data.recipientAddress,
-      subject: data.subject.match(/^Fwd: /) ? data.subject : 'Fwd: ' + data.subject,
+      subject: 'Fwd: ' + data.subject,
       text: content.text
     }
 

--- a/src/backend/mail.js
+++ b/src/backend/mail.js
@@ -178,7 +178,7 @@ export default class MG {
       from: data.senderAddress,
       'h:Reply-To': data.hostAddress,
       to: data.recipientAddress,
-      subject: 'Fwd: ' + data.subject,
+      subject: data.subject.match(/^Fwd: /) ? data.subject : 'Fwd: ' + data.subject,
       text: content.text
     }
 

--- a/src/backend/mail.js
+++ b/src/backend/mail.js
@@ -178,7 +178,7 @@ export default class MG {
       from: data.senderAddress,
       'h:Reply-To': data.hostAddress,
       to: data.recipientAddress,
-      subject: 'Fwd: HELP! I need more people to come to my phonebank',
+      subject: 'Fwd: ' + data.subject,
       text: content.text
     }
 

--- a/src/frontend/components/AdminEventEmailCreationForm.js
+++ b/src/frontend/components/AdminEventEmailCreationForm.js
@@ -47,7 +47,7 @@ class AdminEventEmailCreationForm extends React.Component {
   formSchema = yup.object({
     hostEmail: yup.string().email().required(),
     senderEmail: yup.string().email().required(),
-    subject: yup.string().required(),
+    subject: yup.string().required().matches(/^Fwd: /),
     hostMessage: yup.string().required(),
     senderMessage: yup.string().required(),
     toolPassword: yup.string().required()
@@ -84,7 +84,7 @@ class AdminEventEmailCreationForm extends React.Component {
 	  "Help me fill my event?",
 	  "Can you help turn people out for this Bernie event?"
       ]
-      return this.getRandomSubarray(subjects, 1)[0];
+      return 'Fwd: ' + this.getRandomSubarray(subjects, 1)[0];
   }
 
   renderRecipientInfo() {

--- a/src/frontend/components/AdminEventEmailCreationForm.js
+++ b/src/frontend/components/AdminEventEmailCreationForm.js
@@ -47,6 +47,7 @@ class AdminEventEmailCreationForm extends React.Component {
   formSchema = yup.object({
     hostEmail: yup.string().email().required(),
     senderEmail: yup.string().email().required(),
+    subject: yup.string().required(),
     hostMessage: yup.string().required(),
     senderMessage: yup.string().required(),
     toolPassword: yup.string().required()
@@ -68,6 +69,22 @@ class AdminEventEmailCreationForm extends React.Component {
     }
 
     return shuffled.slice(0, size)
+  }
+
+  getSubject(event) {
+      const subjects = [
+	  "HELP! I need more people to come to my event",
+	  "can you help recruit people for my Bernie event?",
+	  "Pass along my event info to local volunteers?",
+	  "I have extra room -- can you help recruit people?",
+	  "I need help with my Bernie event",
+	  "I want to help Bernie...but I need more people to show up!",
+	  "SOS: I need more people at my event!",
+	  "I have the space, now I just need people to show up!",
+	  "Help me fill my event?",
+	  "Can you help turn people out for this Bernie event?"
+      ]
+      return this.getRandomSubarray(subjects, 1)[0];
   }
 
   renderRecipientInfo() {
@@ -127,7 +144,8 @@ class AdminEventEmailCreationForm extends React.Component {
           <GCForm
             schema={this.formSchema}
             defaultValue={{
-              hostEmail: this.props.event.host.email
+              hostEmail: this.props.event.host.email,
+              subject: this.getSubject(this.props.event)
             }}
             onSubmit={(formValues) => {
               this.refs.mutationHandler.send({
@@ -146,6 +164,12 @@ class AdminEventEmailCreationForm extends React.Component {
             <Form.Field
               name='senderEmail'
               label="Sender Email Address"
+            />
+            <br />
+            <Form.Field
+              name='subject'
+              label="Subject Line"
+	      style={{width: "100%"}}
             />
             <Form.Field
               name='hostMessage'

--- a/src/frontend/mutations/CreateAdminEventEmail.js
+++ b/src/frontend/mutations/CreateAdminEventEmail.js
@@ -39,6 +39,7 @@ export default class CreateAdminEventEmail extends Relay.Mutation {
       hostEmail: this.props.hostEmail,
       senderEmail: this.props.senderEmail,
       adminEmail: this.props.adminEmail,
+      subject: this.props.subject,
       hostMessage: this.props.hostMessage,
       senderMessage: this.props.senderMessage,
       recipients: this.props.recipients,


### PR DESCRIPTION
This also makes the randomly chosen subject line editable by admins on the front end - previously it was set directly in the backend mail code.  The "Fwd: " prefix is still inserted in the backend to make sure that's never accidentally removed.