### PR TITLE
Filter interviewees by distance from a point

### DIFF
--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -204,6 +204,7 @@ ReactDOM.render(
             ...CallAssignmentQueries,
             ...CurrentUserQueries
           }}
+          queryParams={['ll', 'miles']}
           renderLoading={() => <Loading />}
         />
       </Route>

--- a/src/frontend/components/CallAssignment.js
+++ b/src/frontend/components/CallAssignment.js
@@ -409,7 +409,11 @@ ${userFirstName}`
 }
 
 export default Relay.createContainer(CallAssignment, {
-  initialVariables: { id: '' },
+  initialVariables: {
+    id: '',
+    ll: null,  // URL query parameter: point in lat,lon format
+    miles: null  // URL query parameter: radius in miles
+  },
   fragments: {
     callAssignment: () => Relay.QL`
       fragment on CallAssignment {
@@ -428,9 +432,13 @@ export default Relay.createContainer(CallAssignment, {
       fragment on User {
         id
         firstName
-        allCallsMade:callsMade(forAssignmentId:$id)
-        completedCallsMade:callsMade(forAssignmentId:$id,completed:true)
-        intervieweeForCallAssignment(callAssignmentId:$id) {
+        allCallsMade: callsMade(forAssignmentId: $id)
+        completedCallsMade: callsMade(forAssignmentId: $id, completed: true)
+        intervieweeForCallAssignment(
+          callAssignmentId: $id,
+          centerLatLon: $ll,
+          radiusMiles: $miles
+        ) {
           id
           prefix
           firstName

--- a/src/frontend/helpers/convertType.js
+++ b/src/frontend/helpers/convertType.js
@@ -1,0 +1,26 @@
+const convertType = (value) => {
+  if (typeof value === 'object'){
+    let updatedValue = {}
+    Object.keys(value).forEach((key) => {
+      const currentValue = convertType(value[key])
+      if (currentValue != undefined)
+        value[key] = currentValue
+    })
+    return value
+  }
+  else if (value === 'none')
+    return null
+  else if (value === 'true')
+    return true
+  else if (value === 'false')
+    return false
+  else if (value != '' && !isNaN(value) && String(Number(value)) === value)
+    return Number(value)
+  else if (value)
+    return String(value)
+  else {
+    return undefined
+  }
+}
+
+export default convertType

--- a/src/frontend/helpers/getDefaultQuery.js
+++ b/src/frontend/helpers/getDefaultQuery.js
@@ -14,5 +14,5 @@ export default function(defaultParams) {
     }
   }
 
-  return defaultParams
+  return {...defaultParams, ...hashParams}
 }

--- a/src/frontend/helpers/getDefaultQuery.js
+++ b/src/frontend/helpers/getDefaultQuery.js
@@ -1,0 +1,18 @@
+import qs from 'qs'
+import convertType from './convertType'
+
+export default function(defaultParams) {
+  const hashParams = convertType(qs.parse(location.hash.substr(1), { strictNullHandling: true }))
+  if (hashParams.query){
+    try {
+      let newQueryParams = {...defaultParams, ...hashParams.query}
+      newQueryParams.filters = {...defaultParams.filters, ...hashParams.query.filters}
+      return newQueryParams
+    }
+    catch(ex) {
+      console.error('Invalid query parameters', ex)
+    }
+  }
+
+  return defaultParams
+}


### PR DESCRIPTION
Introduces the optional query params `ll` (latitude and longitude of a center point) and `miles` (distance in miles).  If specified, only interviewees whose addresses are within the specified distance of the specified point are shown for a call assignment.