### PR TITLE
Filter interviewees by geo distance, using ?ll=...&miles=...

### DIFF
--- a/src/backend/data/schema.js
+++ b/src/backend/data/schema.js
@@ -456,6 +456,14 @@ const GraphQLListContainer = new GraphQLObjectType({
   interfaces: [nodeInterface]
 })
 
+const GeoPoint = new GraphQLInputObjectType({
+  name: 'GeoPoint',
+  fields: {
+    lat: {type: GraphQLFloat},
+    lon: {type: GraphQLFloat},
+  }
+})
+
 const GraphQLUser = new GraphQLObjectType({
   name: 'User',
   description: 'User of ground control',
@@ -554,10 +562,13 @@ const GraphQLUser = new GraphQLObjectType({
     intervieweeForCallAssignment: {
       type: GraphQLPerson,
       args: {
-        callAssignmentId: {type: GraphQLString}
+        callAssignmentId: {type: GraphQLString},
+        center: {type: GeoPoint},
+        radiusMeters: {type: GraphQLFloat}
       },
-      resolve: async(user, {callAssignmentId}, {rootValue}) => {
-
+      resolve: async(
+        user, {callAssignmentId, center, radiusMeters}, {rootValue}
+      ) => {
         let localCallAssignmentId = fromGlobalId(callAssignmentId)
         if (localCallAssignmentId.type !== 'CallAssignment')
           localCallAssignmentId = callAssignmentId
@@ -646,6 +657,21 @@ const GraphQLUser = new GraphQLObjectType({
           .first()
         if (userAddress)
           query = query.whereNot('bsd_people.cons_id', userAddress.cons_id)
+
+        // Filter by distance from a geographical point.
+        // Spatial ref 4326 is WGS 84, in degrees
+        // Spatial ref 900913 is Google Web Mercator, in meters
+        if (center && radiusMeters > 0) {
+          query = query.whereRaw(`
+            ST_DWithin(bsd_addresses.geom,
+              ST_Transform(
+                ST_SetSRID(ST_MakePoint(${center.lon}, ${center.lat}), 4326),
+                900913
+              ),
+              ${radiusMeters}
+            )
+          `)
+        }
 
         log.info(`Running query: ${query}`)
 


### PR DESCRIPTION
Introduces the optional query params ll (latitude and longitude of a center point) and miles (distance in miles). If specified, only interviewees whose addresses are within the specified distance of the specified point are shown for a call assignment.